### PR TITLE
Add fallToLeft option to change direction of fall

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ $('YOUR-CSS-SELECTOR').solitaireVictory({
   bounce: 0.7                   // Amount of speed conserved on bounce.
   
   endVelocity: 20               // If the element is slower than this, it will not bounce.
+
+  fallToLeft: false             // If set to true, the object will fall to the left instead
+                                // of to the right
   
   
   // PAGE CONFIGURATION

--- a/solitaireVictory.js
+++ b/solitaireVictory.js
@@ -11,6 +11,7 @@
         var stagger = settings.stagger || 200;
         var relativeToDocument = settings.relativeToDocument || false;
         var clear = settings.clear || false;
+        var fallToLeft = settings.fallToLeft || false;
 
         var body = $('body');
         var windowHeight = (relativeToDocument ? $(document).height() : $(window).height());
@@ -42,6 +43,9 @@
 
         var startFall = function(elem, height, stagger) {
             var dx = settings.dx || Math.floor((Math.random()*10)) + 5;
+            if (fallToLeft) {
+                dx = -dx;
+            }
             var copy = elem.clone();
             copy.addClass('solitaire-victory-clone');
             if (relativeToDocument) {


### PR DESCRIPTION
If settings.fallToLeft is set to true, the objects will fall to the left instead of to the right. This is useful for elements that begin on the right side of the page. It could also be used to send objects randomly to the left or right like in the original solitaire animation. For an interesting mirrored effect, two solitaireVictory animations can be triggered on the same object, with fallToLeft enabled on one of the calls.
